### PR TITLE
Fix 'copy-mode-vi'

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -22,9 +22,9 @@ bind p paste-buffer
 #bind-key -t vi-copy 'v' begin-selection
 #bind-key -t vi-copy 'V' rectangle-toggle
 #bind-key -t vi-copy 'y' copy-selection
-bind-key -t copy-mode-vi 'v' begin-selection
-bind-key -t copy-mode-vi 'V' rectangle-toggle
-bind-key -t copy-mode-vi 'y' copy-selection
+bind-key -T copy-mode-vi v send-keys -X begin-selection
+bind-key -T copy-mode-vi V send-keys -X rectangle-toggle
+bind-key -T copy-mode-vi y send-keys -X copy-selection
 
 # Copy text between tmux and x
 #bind y run-shell "tmux show-buffer | xclip -sel clip -i" \; display-message "Copied tmux buffer to system clipboard"


### PR DESCRIPTION
I installed `tmux` on 2018-09-07 using the instructions on
[dbwebb](https://dbwebb.se/kunskap/kom-igang-med-tmux-och-terminalen#config).
The linked config did not work for me and therefore I decided to fix it
using instructions I found on the [dbwebb forum](https://dbwebb.se/forum/)
Updating the 'copy-mode-vi' like this solved my issues with
`tmux`.